### PR TITLE
feat(api-v1.1): enable publish API v1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ npm install --save-dev @plasmohq/edge-addons-api
 
 ### Authentication
 
-You'll need to get a `productId`, `clientId`, `clientSecret`, and `accessTokenUrl` for your project.
+You'll need to get a `productId`, `clientId`, and `apiKey` for your project.
 
 You can get these for your project by following the [Microsoft Edge Add-Ons API guide](https://docs.microsoft.com/en-us/microsoft-edge/extensions-chromium/publish/api/using-addons-api).
 
@@ -59,8 +59,7 @@ import { EdgeAddonsAPI } from "@plasmohq/edge-addons-api"
 const client = new EdgeAddonsAPI({
   productId,
   clientId,
-  clientSecret,
-  accessTokenUrl
+  apiKey
 })
 
 await client.submit({


### PR DESCRIPTION
Start to enable v1.1 of the Publish API, fixing #86.

🚨 This should not be **merged until after 31 December 2025.**

I was 100% unsure about how to actually test this out / use this repo (pnpm workspace issues) when cloning this by itself. I'm not sure what key file to use in the test as well. 

Happy to understand this a bit more and modify the code. 

@louisgv if there's any guidance on this, it would be great so I can update docs/readme and contribute more effectively.