### PR TITLE
fix: wait for publish operation to complete before reporting success

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -7,12 +7,13 @@ test("test upload test.zip artifact", async () => {
   const key = JSON.parse(await readFile("key.json", "utf8")) as Options
 
   const client = new EdgeAddonsAPI(key)
-  const resp = await client.submit({
+  const operationId = await client.submit({
     filePath: "test.zip",
     notes: "Test upload test.zip artifact"
   })
 
-  const publishStatus = await client.getPublishStatus(resp)
+  const publishStatus = await client.getPublishStatus(operationId)
 
-  expect(publishStatus.id).toBe(resp)
+  expect(publishStatus.id).toBe(operationId)
+  expect(publishStatus.status).toBe("Succeeded")
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,9 @@ export class EdgeAddonsAPI {
       return
     }
 
-    return this.publish(notes)
+    const publishOperationId = await this.publish(notes)
+    await this.waitForPublish(publishOperationId)
+    return publishOperationId
   }
 
   async publish(notes = "") {
@@ -132,6 +134,35 @@ export class EdgeAddonsAPI {
         headers: this.getPublishApiDefaultHeaders()
       })
       .json<OperationResponse>()
+  }
+
+  async waitForPublish(
+    operationId: string,
+    retryCount = 10,
+    pollTime = 5000
+  ) {
+    let status: OperationResponse["status"]
+    let attempts = 0
+
+    while (status !== "Succeeded" && attempts < retryCount) {
+      const statusResp = await this.getPublishStatus(operationId)
+
+      if (statusResp.status === "Failed") {
+        throw new Error(
+          statusResp.message ||
+            statusResp.errorCode + ":" + (statusResp.errors || []).join(",")
+        )
+      } else if (statusResp.status === "InProgress") {
+        await wait(pollTime)
+      }
+
+      status = statusResp.status
+      attempts++
+    }
+
+    if (status !== "Succeeded") {
+      throw new Error("Publish operation timed out")
+    }
   }
 
   async waitForUpload(


### PR DESCRIPTION
## Summary

`submit()` previously fired the publish request and returned immediately after receiving a [202 Accepted](https://learn.microsoft.com/en-us/microsoft-edge/extensions-chromium/publish/api/addons-api-reference?tabs=v1-1#status-codes), without polling the [publish status endpoint](https://learn.microsoft.com/en-us/microsoft-edge/extensions-chromium/publish/api/addons-api-reference?tabs=v1-1#check-the-publishing-status) to verify the operation completed. The `getPublishStatus()` method existed but was never called from the submit flow.

This meant async publish failures were silently ignored and the extension remained as a draft. The following [error codes](https://learn.microsoft.com/en-us/microsoft-edge/extensions-chromium/publish/api/addons-api-reference?tabs=v1-1#check-the-publishing-status) would go undetected:

- `NoModulesUpdated` — no changes since last submission
- `InProgressSubmission` — another submission already under review
- `SubmissionValidationError` — submission validation failures
- `ModuleStateUnPublishable` — extension has invalid modules
- `UnpublishInProgress` — extension is being unpublished
- `CreateNotAllowed` — can't create new extension

### Changes

- `submit()` now calls `waitForPublish()` after `publish()`, polling `getPublishStatus()` until the operation reaches `Succeeded` or `Failed`
- Mirrors the existing `waitForUpload()` pattern and [Microsoft's reference implementation](https://learn.microsoft.com/en-us/microsoft-edge/extensions/update/api/using-addons-api?tabs=v1-1) (10 retries, 5s intervals)
- Test updated to assert `publishStatus.status === "Succeeded"`

## Test plan

- [ ] Verify integration test passes with `pnpm dlx @plasmohq/mystic-box test-zip 0.0.8` + valid `key.json`
- [ ] Verify failed publishes throw with the actual Microsoft error message
- [ ] Verify timeout after max retries throws `"Publish operation timed out"`